### PR TITLE
修复了余额小数点后位数显示过多的问题

### DIFF
--- a/vultr-helper.js
+++ b/vultr-helper.js
@@ -32,7 +32,7 @@ function getAccountInfo(apiKey) {
             $("progress_label").text = "Charges this month: $" + data.pending_charges;
             // console.log(balance);
             $("charges").value = balance;
-            $("remaining_credit").text = "$" + Math.abs(remainCredit);
+            $("remaining_credit").text = "$" + Math.abs(remainCredit).toFixed(2);
             $("progress_percent").text = percentBalance;
         }
     });


### PR DESCRIPTION
余额小数点后也许应该显示两位？🐱

![issue](https://user-images.githubusercontent.com/37136447/55665346-493fa500-5870-11e9-8aec-43f59021e059.jpeg)
